### PR TITLE
For Centos 7 added install of open-vm-tools (vmware recommended way)

### DIFF
--- a/centos7/scripts/vmtools.sh
+++ b/centos7/scripts/vmtools.sh
@@ -10,11 +10,6 @@ fi
 
 if [[ $PACKER_BUILDER_TYPE =~ vmware ]]; then
 yum -y install net-tools
-mount -o loop /home/vagrant/linux.iso /mnt
-cd /tmp
-tar zxf /mnt/VMwareTools-*.tar.gz
-umount /mnt
-/tmp/vmware-tools-distrib/vmware-install.pl --default
-rm -rf /tmp/vmware-tools-distrib
-rm -rf /home/vagrant/linux.iso
+yum -y install epel-release
+yum -y install open-vm-tools
 fi


### PR DESCRIPTION
For Centos 7 added install of open-vm-tools (vmware recommended way), to solve issue with non-compiling vmware tools